### PR TITLE
Add setOriginTo: to git cli repository

### DIFF
--- a/src/Iceberg-Git-CLI/IceGitCliRepository.class.st
+++ b/src/Iceberg-Git-CLI/IceGitCliRepository.class.st
@@ -837,6 +837,15 @@ IceGitCliRepository >> setHead: aGtIceGitLocalBranch [
 	head := nil
 ]
 
+{ #category : #'API - remotes' }
+IceGitCliRepository >> setOriginTo: url [
+	self
+		runGitWithArgs: {'remote'.
+				'set-url'.
+				'origin'.
+				url} asOrderedCollection
+]
+
 { #category : #private }
 IceGitCliRepository >> statusEnumFrom: statusChar [
 	| flagMap |

--- a/src/Iceberg-Git-CLI/PureGitFile.class.st
+++ b/src/Iceberg-Git-CLI/PureGitFile.class.st
@@ -35,11 +35,6 @@ PureGitFile >> blame [
 	^ self repository queries blame: self path
 ]
 
-
-{ #category : #accessing }
-PureGitFile >> extension [
-	^ ($. split: self basename) last
-]
 { #category : #testing }
 PureGitFile >> canBeRestored [
 	^ self isTracked and: [ self isModifiedInWorkTree ]
@@ -106,6 +101,11 @@ PureGitFile >> delete [
 { #category : #testing }
 PureGitFile >> exists [
 	^ self fileReference exists
+]
+
+{ #category : #accessing }
+PureGitFile >> extension [
+	^ ($. split: self basename) last
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
This PR makes it possible to actually switch the origin of the Git CLI repository, allowing to move over to forks if desired.

Cheers